### PR TITLE
Fix bug where custom headers wouldn't make their way to iter8/fortio

### DIFF
--- a/charts/load-test-http/Chart.yaml
+++ b/charts/load-test-http/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: load-test-http
-version: 0.1.0
+version: 0.1.1
 description: Load test, benchmark, and validate HTTP
 type: application
 keywords:

--- a/charts/load-test-http/templates/_experiment.tpl
+++ b/charts/load-test-http/templates/_experiment.tpl
@@ -40,11 +40,11 @@
     {{- $percentiles := list }}
     {{- range $key, $value := .Values.SLOs }}
     {{- if (regexMatch "http/latency-p\\d+(?:\\.\\d)?$" $key) }}
-    {{- $percentiles = append $percentiles (trimPrefix "http/latency-p" $key | float64 ) }}    
+    {{- $percentiles = append $percentiles (trimPrefix "http/latency-p" $key | float64 ) }}
     {{- end }}
     {{- end }}
     {{- if $percentiles }}
-    percentiles: 
+    percentiles:
 {{ toYaml ($percentiles | uniq) | indent 4 }}
     {{- end }}
 
@@ -52,8 +52,8 @@
     versionInfo:
     - url: {{ required "A valid url value is required!" .Values.url | toString }}
     {{- if .Values.headers }}
-    headers:
-{{ toYaml .Values.headers | indent 6 }}
+      headers:
+{{ toYaml .Values.headers | indent 8 }}
     {{- end }}
 
 {{- if .Values.SLOs }}


### PR DESCRIPTION
We expect headers to be a nested object in an array of objects under the `versionInfo` section in the generated experiments.yaml file (see definition of `versionHTTP` struct [here](https://github.com/iter8-tools/iter8/blob/master/base/collect_http.go#L17)). 

Change `templates/_experiment.tpl` to ensure that headers get properly passed on to iter8 and fortio. 

We can test that custom headers don't get passed on by defining key value pairs in the `headers` section of `values.yaml` and subsequently running `iter8 run`. 

```yaml
headers:
  foo: bar 
``` 
