### PR TITLE
update iter8 version

### DIFF
--- a/charts/abn-service/Chart.yaml
+++ b/charts/abn-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: iter8-abn
-version: 0.1.3
+version: 0.1.4
 description: Iter8 ABn support serivce
 type: application
 keywords:
@@ -15,4 +15,4 @@ maintainers:
 - name: Iter8
   email: iter8-tools@gmail.com
 icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
-appVersion: v0.11
+appVersion: v0.12

--- a/charts/abn-service/Chart.yaml
+++ b/charts/abn-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: iter8-abn
 version: 0.1.4
-description: Iter8 ABn support serivce
+description: Iter8 ABn support service
 type: application
 keywords:
 - Iter8

--- a/charts/abn-service/values.yaml
+++ b/charts/abn-service/values.yaml
@@ -1,5 +1,5 @@
 ### ABn service image
-image: iter8/iter8:0.11
+image: iter8/iter8:0.12
 
 service: 
   port: 50051


### PR DESCRIPTION
Make Iter8 v0.12 the default for abn chart
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>