### PR TITLE
default resourceTypes for controller deploy

### DIFF
--- a/charts/traffic/Chart.yaml
+++ b/charts/traffic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traffic
-version: 0.1.3
+version: 0.1.4
 description: Iter8 traffic controller
 type: application
 keywords:

--- a/charts/traffic/values.yaml
+++ b/charts/traffic/values.yaml
@@ -1,6 +1,45 @@
-### AutoX service image
+### Controller image
 image: iter8/iter8:0.13
 
+### default resync time for controller
+defaultResync: 15m
+
+### flag indicating whether installed as cluster scoped or (default) namespace scoped
+# clusterScoped: true
+
+### list of resource types to watch. For each resource type, an Iter8 shortname is mapped to a group, version, and resource.
+### to add types to watch, any shortname can be used
+### Where a condition is identified, it identifies the status condition on an object that should be inspected to determine 
+### if the resource is "ready".
+resourceTypes:
+  svc:
+    Group: ""
+    Version: v1
+    Resource: services
+  cm:
+    Group: ""
+    Version: v1
+    Resource: configmaps
+  deploy:
+    Group: apps
+    Version: v1
+    Resource: deployments
+    conditions:
+    - name: Available
+      status: "True"
+  isvc:
+    Group: serving.kserve.io
+    Version: v1beta1
+    Resource: inferenceservices
+    conditions:
+    - name: Ready
+      status: "True"
+  vs:
+    Group: networking.istio.io
+    Version: v1beta1
+    Resource: virtualservices
+
+### log level. Must be one of trace, debug, info, warning, error
 logLevel: info
 
 ### Resource limits

--- a/kustomize/traffic/base/configmap.yaml
+++ b/kustomize/traffic/base/configmap.yaml
@@ -8,6 +8,10 @@ data:
     image: iter8/iter8:0.13
     logLevel: info
     resourceTypes:
+      cm:
+        Group: ""
+        Resource: configmaps
+        Version: v1
       deploy:
         Group: apps
         Resource: deployments
@@ -16,6 +20,9 @@ data:
         Group: serving.kserve.io
         Resource: inferenceservices
         Version: v1beta1
+        conditions:
+        - name: Ready
+          status: "True"
       svc:
         Group: ""
         Resource: services


### PR DESCRIPTION
Add default resource types for controller helm chart, update kustomize config
Needed to simplify install (no need for config file)